### PR TITLE
Initial Implementation of cache management

### DIFF
--- a/js/admin.js
+++ b/js/admin.js
@@ -1,0 +1,48 @@
+jQuery(document).ready(function ($) {
+  let noticeCount = 0
+  $('#clear-cache-button').on('click', function (e) {
+    clearCacheButtonParent = $(this).parent()
+    $.ajax({
+      url: ajax_obj.ajax_url,
+      type: 'get',
+      data: {
+        action: 'lufp_clear_image_cache',
+      },
+    })
+      .done(function (response) {
+        return response.data
+      })
+      .then(function (data) {
+        data = data.data
+        if (data.success) {
+          add_notice(
+            clearCacheButtonParent,
+            'Your image cache has been cleared',
+            'success',
+          )
+        }
+        if (!data.success) {
+          add_notice(
+            clearCacheButtonParent,
+            `Your image cache has <em>not</em> been cleared: ${data.message}`,
+            'warning',
+          )
+        }
+      })
+  })
+
+  function add_notice(target, message = '', type = 'success') {
+    console.log(`Notice Count: ${noticeCount}`)
+    target.prepend(
+      `<div id="lufp-notice-${noticeCount}" class="notice notice-${type} is-dismissible lufp-notice"><p>${message}</p></div>`,
+    )
+
+    setTimeout(
+      function (n) {
+        $(`#lufp-notice-${n}`).fadeOut()
+      },
+      5000,
+      [noticeCount++],
+    )
+  }
+})

--- a/plugin.php
+++ b/plugin.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
 Plugin Name: Load Uploads From Production
 Description: This plugin overwrites attachment URLs with the production site if they are not found on the staging site. Please de-activate in production.
@@ -9,11 +10,71 @@ Author URI: http://pie.co.de
 
 namespace PIE\LoadUploadsFromProduction;
 
+use \Exception;
+
 const PROD_URL_SETTING_ID = __NAMESPACE__ . ':production_url';
 const PROD_IMG_URL_CACHE_ID = __NAMESPACE__ . ':cached_image_urls';
+const CLEAR_PROD_IMG_URL_CACHE_ID = __NAMESPACE__ . ':clear_image_urls_cache';
 
 add_action('admin_init', __NAMESPACE__ . '\hookup_setting_field');
 add_action('init', __NAMESPACE__ . '\maybe_hookup_uploads_filter');
+add_action('init', __NAMESPACE__ . '\enqueue_scripts');
+
+/**
+ * Enqueues scripts
+ *
+ * @hooked init @10
+ * @return void
+ */
+function enqueue_scripts()
+{
+    wp_enqueue_script(
+        $handle = 'load-uploads-from-production-js',
+        $src = plugin_dir_url(__FILE__) . '/js/admin.js',
+        $deps = ['jquery'],
+        $ver = filemtime(plugin_dir_path(__FILE__) . '/js/admin.js'),
+        $in_footer = true
+    );
+    wp_localize_script(
+        $handle = 'load-uploads-from-production-js',
+        $object_name = 'ajax_obj',
+        $l10n = [
+            'ajax_url' => admin_url('admin-ajax.php')
+        ]
+    );
+
+    add_action('wp_ajax_lufp_clear_image_cache', __NAMESPACE__ . '\maybe_clear_image_cache');
+}
+
+/**
+ * Ajax action to try clear image cahce
+ */
+function maybe_clear_image_cache()
+{
+    try {
+        $cache = get_option(PROD_IMG_URL_CACHE_ID);
+        $cache_size = is_array($cache) ? sizeof($cache) : 0;
+        $updated = update_option(PROD_IMG_URL_CACHE_ID, []);
+        
+        if ($cache_size < 1) {
+            throw new Exception("There was no cache to clear", 1);
+        }
+        if (!$updated) {
+            throw new Exception("Internal error. Please try again or seek admin assistance", 2);
+        }
+        wp_send_json_success([
+            'success' => true,
+            'cache' => $cache,
+            'items_cleared' => $cache_size
+            ], 200);
+    } catch (\Exception $ex) {
+        wp_send_json_error([
+            'success' => false,
+            'message' => $ex->getMessage(),
+            'errCode' => $ex->getCode()
+        ]);
+    }
+}
 
 /**
  * Checks to see if we're on the production site, and if not we hook up the filter
@@ -34,22 +95,32 @@ function maybe_hookup_uploads_filter()
  * @hooked admin_init@10
  * @return void
  */
-function hookup_setting_field(){
+function hookup_setting_field()
+{
+    register_setting(
+        'general',
+        PROD_URL_SETTING_ID,
+        [
+            'type' => 'string',
+            'sanitize_callback' => 'sanitize_url',
+        ]
+    );
 
-	register_setting( 'general', PROD_URL_SETTING_ID , [
-		'type'=>'string',
-		'sanitize_callback'=>'sanitize_url',
-		]
-	);	
-
-	add_settings_field(  
-		PROD_URL_SETTING_ID,                      
-		'Production Address (URL)',               
-		__NAMESPACE__ . '\textbox_callback',   
-		'general' ,                     
-		'default'
-	);
-
+    add_settings_field(
+        PROD_URL_SETTING_ID,
+        'Production Address (URL)',
+        __NAMESPACE__ . '\textbox_callback',
+        'general',
+        'default'
+    );
+    
+    add_settings_field(
+        CLEAR_PROD_IMG_URL_CACHE_ID,
+        'Image Cache',
+        __NAMESPACE__ . '\cache_clear_button_callback',
+        'general',
+        'default'
+    );
 }
 
 /**
@@ -57,16 +128,28 @@ function hookup_setting_field(){
  *
  * @return void
  */
-function textbox_callback() { 
-	$production_url_value = get_option(PROD_URL_SETTING_ID)?:''; 
-	echo sprintf(file_get_contents(plugin_dir_path(__FILE__) . 'templates/production-url-field.html'), PROD_URL_SETTING_ID, $production_url_value);
+function textbox_callback()
+{
+    $production_url_value = get_option(PROD_URL_SETTING_ID) ?: '';
+    echo sprintf(file_get_contents(plugin_dir_path(__FILE__) . 'templates/production-url-field.html'), PROD_URL_SETTING_ID, $production_url_value);
+}
+
+/**
+ * Outputs the HTML for the Cache Clear button
+ *
+ * @return void
+ */
+function cache_clear_button_callback()
+{
+    // echo '<button type="button" id="view-cache-button" class="button-primary" style="margin-right: 1rem">View Cache</button>';
+    echo '<button type="button" id="clear-cache-button" class="button">Clear Cache</button>';
 }
 
 /**
  * Looks for a valid url in the first element of an array and if found, checks if the file is accessible via HTTP.
- * If not, it replaces any instances of the home URL with the production URL. This is primarily used to fall back 
+ * If not, it replaces any instances of the home URL with the production URL. This is primarily used to fall back
  * to the live site for images that are not found in the dev or staging environments.
- * 
+ *
  * Note that we cache these lookups once and once only to save on multiple HTTP requests in the background on
  * every page load. The cache needs to be removed from the DB manually to purge.
  *
@@ -78,18 +161,17 @@ function textbox_callback() {
 function replace_home_url_with_production($src)
 {
     if (is_array($src) && filter_var($src[0], FILTER_VALIDATE_URL)) {
-
-		$cache = get_option(PROD_IMG_URL_CACHE_ID);
-		if(isset($cache[$src[0]])){
-			$src[0] = $cache[$src[0]];
-		} else {
-			$file_headers = @get_headers($src[0]);
-			if ($file_headers[0] == 'HTTP/1.1 404 Not Found') {
-					$src[0] = str_replace(home_url(), PROD_URL_SETTING_ID, $src[0]);
-			}
-			$cache[$src[0]] = $src[0];
-			update_option(PROD_IMG_URL_CACHE_ID, $cache);
-		}
+        $cache = get_option(PROD_IMG_URL_CACHE_ID);
+        if (isset($cache[$src[0]])) {
+            $src[0] = $cache[$src[0]];
+        } else {
+            $file_headers = @get_headers($src[0]);
+            if ($file_headers[0] == 'HTTP/1.1 404 Not Found') {
+                $src[0] = str_replace(home_url(), PROD_URL_SETTING_ID, $src[0]);
+            }
+            $cache[$src[0]] = $src[0];
+            update_option(PROD_IMG_URL_CACHE_ID, $cache);
+        }
     }
     return $src;
 }


### PR DESCRIPTION
The cache can currently be cleared from the Settings > General page using an ajax action to replace the cache option's current value with an empty array. Error handling is in place with disappearing notifications above the option